### PR TITLE
Hello! Add support Freebsd, plz!

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,8 +44,8 @@ class transmission_daemon (
     $config_path = "/usr/local/etc/transmission"
     $daemon_name = "transmission"
     if ( $rc_conf == True ){
-      puppet-rc.conf::param{"transmission_enable": value => "YES",}
-      puppet-rc.conf::param{"transmission_download_dir": value => "${download_dir}", }
+      puppet-rc_conf::param{"transmission_enable": value => "YES", }
+      puppet-rc_conf::param{"transmission_download_dir": value => "${download_dir}", }
     }
   } else {
     $config_path = "/etc/transmission-daemon"


### PR DESCRIPTION
Hi! I like u puppet module for transmission, but it don't have support FreeBSD os. I change manifests, now it work in FreeBSD10. 

P.S. I using me module for change rc.conf https://github.com/fessoga5/puppet-rc_conf.git. U can add it as require or create\download another module! Thanks!
