### PR TITLE
Add download_conf_dir in rc.conf for FreeBSD

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,7 +15,8 @@ $blocklist_url:: An url to a block list. By default this option is not set.
 
 == Requires: 
 
-Nothing.
+puppet-rc_conf by fessoga5
+https://github.com/fessoga5/puppet-rc_conf.git 
 
 == Sample Usage:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class transmission_daemon (
     if ( $rc_conf == True ){
       puppet-rc_conf::param{"transmission_enable": value => "YES", }
       puppet-rc_conf::param{"transmission_download_dir": value => "${download_dir}", }
+      puppet-rc_conf::param{"transmission_conf_dir": value => "${config_path}", }
     }
   } else {
     $config_path = "/etc/transmission-daemon"


### PR DESCRIPTION
Hello! I find bug in the module. Transmission use /usr/local/etc/transmission/home/settings.json for default, but it should is /usr/local/etc/transmission/settings.json. I change module and push. U can commit me changes?
